### PR TITLE
chore(apexvoid-trading-bot): expect 3 services (add redis)

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -51,7 +51,7 @@ projects:
     repo_dir: apexvoid-trading-bot
     source: deployment-template       # holds docker-compose.yml.j2
     compose_template: docker-compose.yml.j2
-    expected_services: 2              # bot + postgres
+    expected_services: 3              # bot + postgres + redis
 
 # --- Per-project non-secret settings -----------------------------------------
 registry_namespace: mich43l


### PR DESCRIPTION
The watcher now persists TP/SL progress + bar cursor in Redis, so the compose template ships a redis service alongside bot + postgres. Bump the post-deploy service count check accordingly.